### PR TITLE
Change Positions of Action Buttons

### DIFF
--- a/src/public/css/rename_options.css
+++ b/src/public/css/rename_options.css
@@ -49,14 +49,6 @@
     cursor: not-allowed;
 }
 
-.button-container {
-    position: absolute;
-    bottom: 20px;
-    right: 20px;
-    display: flex;
-    gap: 10px;
-}
-
 .action-button {
     padding: 8px 16px;
     border: none;

--- a/src/views/partials/filearea.ejs
+++ b/src/views/partials/filearea.ejs
@@ -7,7 +7,13 @@
                 <% currentPath = currentPath + '/' + part; %>
                 > <a href="/?dir=<%= encodeURIComponent(currentPath) %>"><%= part %></a>
             <% } %>
+            <div class="button-container" style="text-align: right;">
+                <button class="action-button reset-btn" id="resetButton">Reset</button>
+                <button class="action-button dry-run-btn" id="dryRunButton">Dry Run</button>
+                <button class="action-button rename-btn" id="renameButton">Rename</button>
+              </div>
         <% } %>
+
     </div>
 
     <div class="file-table-container">

--- a/src/views/partials/rename_options.ejs
+++ b/src/views/partials/rename_options.ejs
@@ -9,10 +9,4 @@
         <%- include('./rename_modules/rm07_numbering.ejs') %>
         </div>
     </div>
-
-    <!-- <div class="button-container">
-        <button class="action-button reset-btn" id="resetButton">Reset</button>
-        <button class="action-button dry-run-btn" id="dryRunButton">Dry Run</button>
-        <button class="action-button rename-btn" id="renameButton">Rename</button>
-    </div> -->
 </div>


### PR DESCRIPTION
Closes #23

## Summary by Sourcery

Move action buttons from the rename options modal to the file area header

Bug Fixes:
- Removed absolute positioning of button container in CSS

Enhancements:
- Relocated action buttons (Reset, Dry Run, Rename) to improve user interface layout

Chores:
- Removed commented-out button container in rename options template